### PR TITLE
add other dice

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,11 @@ import { OrbitControls } from "@react-three/drei";
 import { Suspense } from "react";
 import { Color } from "three";
 
+import D4 from "./D4";
+import D6 from "./D6";
+import D8 from "./D8";
+import D10 from "./D10";
+import D12 from "./D12";
 import D20 from "./D20";
 import TablePlane from "./TablePlane";
 
@@ -29,8 +34,12 @@ const App = () => {
           <TablePlane />
         </Suspense>
 
-        <D20 position={[-2, 3, -5]} color={new Color("red")} />
-        <D20 position={[2, 3, -5]} color={new Color("green")} />
+        <D20 position={[-2, 3, -5]} color={new Color("purple")} />
+        <D12 position={[1, 3, 5]} color={new Color("blue")} />
+        <D10 position={[-6, 3, 5]} color={new Color("red")} />
+        <D8 position={[3, 3, 5]} color={new Color("orange")} />
+        <D6 position={[2, 3, -5]} color={new Color("green")} />
+        <D4 position={[-1, 3, 5]} color={new Color("grey")} />
       </Physics>
       <OrbitControls />
     </Canvas>

--- a/src/D10.jsx
+++ b/src/D10.jsx
@@ -1,0 +1,98 @@
+import { useConvexPolyhedron } from "@react-three/cannon";
+import { useMemo, useState } from "react";
+import { PolyhedronGeometry } from "three";
+
+import Dx from "./Dx";
+
+import CannonUtils from "./CannonUtils";
+import { D10_RADIUS } from "./constants";
+
+const D10 = ({ position, color }) => {
+  const [collidingPlane, setCollidingPlane] = useState(false);
+  const [lastContactId, setLastContactId] = useState(null);
+
+  const geometryArgs = useMemo(() => {
+    const sides = 10;
+    const vertices = [
+      [0, 0, 1],
+      [0, 0, -1],
+    ].flat();
+
+    for (let i = 0; i < sides; ++i) {
+      const b = (i * Math.PI * 2) / sides;
+      vertices.push(-Math.cos(b), -Math.sin(b), 0.105 * (i % 2 ? 1 : -1));
+    }
+
+    const faces = [
+      [0, 2, 3],
+      [0, 3, 4],
+      [0, 4, 5],
+      [0, 5, 6],
+      [0, 6, 7],
+      [0, 7, 8],
+      [0, 8, 9],
+      [0, 9, 10],
+      [0, 10, 11],
+      [0, 11, 2],
+      [1, 3, 2],
+      [1, 4, 3],
+      [1, 5, 4],
+      [1, 6, 5],
+      [1, 7, 6],
+      [1, 8, 7],
+      [1, 9, 8],
+      [1, 10, 9],
+      [1, 11, 10],
+      [1, 2, 11],
+    ].flat();
+    return [vertices, faces];
+  }, []);
+
+  const geometry = useMemo(
+    () =>
+      new PolyhedronGeometry(geometryArgs[0], geometryArgs[1], D10_RADIUS, 0),
+    [geometryArgs]
+  );
+
+  const args = useMemo(
+    () => CannonUtils.toConvexPolyhedronProps(geometry, 3),
+    [geometry]
+  );
+  const [ref, api] = useConvexPolyhedron(() => ({
+    args,
+    mass: 1,
+    position,
+    restitution: 0.8,
+    onCollideBegin: (e) => {
+      if (e.body.geometry.type === "PlaneGeometry") {
+        setCollidingPlane(true);
+      }
+    },
+    onCollide: (e) => {
+      if (lastContactId !== e.contact.id) {
+        setLastContactId(e.contact.id);
+      }
+    },
+    onCollideEnd: (e) => {
+      if (e.body.geometry.type === "PlaneGeometry") {
+        setCollidingPlane(false);
+      }
+    },
+  }));
+
+  return (
+    <Dx
+      api={api}
+      ref={ref}
+      geometry={geometry}
+      position={position}
+      color={color}
+      lastContactId={lastContactId}
+      collidingPlane={collidingPlane}
+    >
+      <polyhedronGeometry args={[...geometryArgs, D10_RADIUS, 0]} />
+    </Dx>
+  );
+};
+
+export default D10;

--- a/src/D12.jsx
+++ b/src/D12.jsx
@@ -1,17 +1,17 @@
 import { useConvexPolyhedron } from "@react-three/cannon";
 import { useMemo, useState } from "react";
-import { IcosahedronGeometry } from "three";
+import { DodecahedronGeometry } from "three";
 
 import Dx from "./Dx";
 
 import CannonUtils from "./CannonUtils";
-import { D20_RADIUS } from "./constants";
+import { D12_RADIUS } from "./constants"; 
 
-const D20 = ({ position, color }) => {
+const D12 = ({ position, color }) => {
   const [collidingPlane, setCollidingPlane] = useState(false);
   const [lastContactId, setLastContactId] = useState(null);
 
-  const geometry = useMemo(() => new IcosahedronGeometry(D20_RADIUS, 0), []);
+  const geometry = useMemo(() => new DodecahedronGeometry(D12_RADIUS, 0), []);
   const args = useMemo(
     () => CannonUtils.toConvexPolyhedronProps(geometry),
     [geometry]
@@ -19,7 +19,7 @@ const D20 = ({ position, color }) => {
   const [ref, api] = useConvexPolyhedron(() => ({
     args,
     mass: 1,
-    position: position,
+    position,
     restitution: 0.8,
     onCollideBegin: (e) => {
       if (e.body.geometry.type === "PlaneGeometry") {
@@ -48,9 +48,9 @@ const D20 = ({ position, color }) => {
       lastContactId={lastContactId}
       collidingPlane={collidingPlane}
     >
-      <icosahedronGeometry args={[D20_RADIUS, 0]} />
+      <dodecahedronGeometry args={[D12_RADIUS]} />
     </Dx>
   );
 };
 
-export default D20;
+export default D12;

--- a/src/D4.jsx
+++ b/src/D4.jsx
@@ -1,17 +1,17 @@
 import { useConvexPolyhedron } from "@react-three/cannon";
 import { useMemo, useState } from "react";
-import { IcosahedronGeometry } from "three";
+import { TetrahedronGeometry } from "three";
 
 import Dx from "./Dx";
 
 import CannonUtils from "./CannonUtils";
-import { D20_RADIUS } from "./constants";
+import { D4_RADIUS } from "./constants";
 
-const D20 = ({ position, color }) => {
+const D4 = ({ position, color }) => {
   const [collidingPlane, setCollidingPlane] = useState(false);
   const [lastContactId, setLastContactId] = useState(null);
 
-  const geometry = useMemo(() => new IcosahedronGeometry(D20_RADIUS, 0), []);
+  const geometry = useMemo(() => new TetrahedronGeometry(D4_RADIUS, 0), []);
   const args = useMemo(
     () => CannonUtils.toConvexPolyhedronProps(geometry),
     [geometry]
@@ -19,8 +19,8 @@ const D20 = ({ position, color }) => {
   const [ref, api] = useConvexPolyhedron(() => ({
     args,
     mass: 1,
-    position: position,
-    restitution: 0.8,
+    position,
+    restitution: 0.9,
     onCollideBegin: (e) => {
       if (e.body.geometry.type === "PlaneGeometry") {
         setCollidingPlane(true);
@@ -47,10 +47,11 @@ const D20 = ({ position, color }) => {
       color={color}
       lastContactId={lastContactId}
       collidingPlane={collidingPlane}
+      inertiaMod={0.02}
     >
-      <icosahedronGeometry args={[D20_RADIUS, 0]} />
+      <tetrahedronGeometry args={[D4_RADIUS, 0]} />
     </Dx>
   );
 };
 
-export default D20;
+export default D4;

--- a/src/D6.jsx
+++ b/src/D6.jsx
@@ -1,25 +1,20 @@
-import { useConvexPolyhedron } from "@react-three/cannon";
+import { useBox } from "@react-three/cannon";
 import { useMemo, useState } from "react";
-import { IcosahedronGeometry } from "three";
+import { BoxGeometry } from "three";
 
 import Dx from "./Dx";
 
-import CannonUtils from "./CannonUtils";
-import { D20_RADIUS } from "./constants";
+import { D6_RADIUS } from "./constants";
 
-const D20 = ({ position, color }) => {
+const D6 = ({ position, color }) => {
   const [collidingPlane, setCollidingPlane] = useState(false);
   const [lastContactId, setLastContactId] = useState(null);
 
-  const geometry = useMemo(() => new IcosahedronGeometry(D20_RADIUS, 0), []);
-  const args = useMemo(
-    () => CannonUtils.toConvexPolyhedronProps(geometry),
-    [geometry]
-  );
-  const [ref, api] = useConvexPolyhedron(() => ({
-    args,
+  const geometry = useMemo(() => new BoxGeometry(D6_RADIUS), []);
+  const [ref, api] = useBox(() => ({
+    args: [D6_RADIUS, D6_RADIUS, D6_RADIUS],
     mass: 1,
-    position: position,
+    position,
     restitution: 0.8,
     onCollideBegin: (e) => {
       if (e.body.geometry.type === "PlaneGeometry") {
@@ -48,9 +43,9 @@ const D20 = ({ position, color }) => {
       lastContactId={lastContactId}
       collidingPlane={collidingPlane}
     >
-      <icosahedronGeometry args={[D20_RADIUS, 0]} />
+      <boxGeometry args={[D6_RADIUS, D6_RADIUS, D6_RADIUS]} />
     </Dx>
   );
 };
 
-export default D20;
+export default D6;

--- a/src/D8.jsx
+++ b/src/D8.jsx
@@ -1,25 +1,25 @@
 import { useConvexPolyhedron } from "@react-three/cannon";
 import { useMemo, useState } from "react";
-import { IcosahedronGeometry } from "three";
+import { OctahedronGeometry } from "three";
 
 import Dx from "./Dx";
 
 import CannonUtils from "./CannonUtils";
-import { D20_RADIUS } from "./constants";
+import { D8_RADIUS } from "./constants";
 
-const D20 = ({ position, color }) => {
+const D8 = ({ position, color }) => {
   const [collidingPlane, setCollidingPlane] = useState(false);
   const [lastContactId, setLastContactId] = useState(null);
 
-  const geometry = useMemo(() => new IcosahedronGeometry(D20_RADIUS, 0), []);
+  const geometry = useMemo(() => new OctahedronGeometry(D8_RADIUS, 0), []);
   const args = useMemo(
-    () => CannonUtils.toConvexPolyhedronProps(geometry),
+    () => CannonUtils.toConvexPolyhedronProps(geometry, 3),
     [geometry]
   );
   const [ref, api] = useConvexPolyhedron(() => ({
     args,
     mass: 1,
-    position: position,
+    position,
     restitution: 0.8,
     onCollideBegin: (e) => {
       if (e.body.geometry.type === "PlaneGeometry") {
@@ -48,9 +48,9 @@ const D20 = ({ position, color }) => {
       lastContactId={lastContactId}
       collidingPlane={collidingPlane}
     >
-      <icosahedronGeometry args={[D20_RADIUS, 0]} />
+      <octahedronGeometry args={[D8_RADIUS]} />
     </Dx>
   );
 };
 
-export default D20;
+export default D8;

--- a/src/Dx.jsx
+++ b/src/Dx.jsx
@@ -1,0 +1,146 @@
+import { Text } from "@react-three/drei";
+import { useFrame } from "@react-three/fiber";
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react";
+import { Color } from "three";
+
+import { ZEROISH } from "./constants";
+import CannonUtils from "./CannonUtils";
+import {
+  randomAngularVelocity,
+  randomRotation,
+  randomVelocity,
+} from "./Vec3Utils";
+
+const Dx = forwardRef(
+  (
+    {
+      children,
+      api,
+      inertiaMod,
+      geometry,
+      position,
+      color,
+      lastContactId,
+      collidingPlane,
+    },
+    ref
+  ) => {
+    const [hovered, setHover] = useState(false);
+    const [lowVelocity, setLowVelocity] = useState(false);
+    const [atRest, setAtRest] = useState(false);
+    const centroidsRef = useRef([]);
+    const interval = useRef(null);
+
+    const resetRoll = useCallback(() => {
+      setHover(false);
+      setLowVelocity(false);
+      api.position.set(...position);
+      api.rotation.set(...randomRotation());
+      api.velocity.set(...randomVelocity());
+      api.angularVelocity.set(...randomAngularVelocity());
+    }, [api]);
+
+    const onRest = useCallback(() => {
+      setAtRest(true);
+            console.log(`You rolled a ${lastContactId + 1}!`);
+    }, [lastContactId]);
+
+    useEffect(() => {
+      // this effect checks the velocity of the die, and if any velocity values are low enough,
+      // it then checks the magnitude of the velocity. if that is low enough, sets lowVelocity to true
+      const inertiaFactor = ZEROISH + (inertiaMod ?? 0);
+      const unsubscribe = api.velocity.subscribe((velocity) => {
+        if (
+          Math.abs(velocity[0]) < inertiaFactor ||
+          Math.abs(velocity[1]) < inertiaFactor ||
+          Math.abs(velocity[2]) < inertiaFactor
+        ) {
+          const x = Math.pow(Math.abs(velocity[0]), 2);
+          const y = Math.pow(Math.abs(velocity[1]), 2);
+          const z = Math.pow(Math.abs(velocity[2]), 2);
+          const magnitude = Math.sqrt(x + y + z);
+          if (magnitude < inertiaFactor) {
+            if (!lowVelocity) {
+              setLowVelocity(true);
+            }
+          } else if (lowVelocity) {
+            setLowVelocity(false);
+          }
+        }
+      });
+      return unsubscribe;
+    }, [api, inertiaMod, lowVelocity]);
+
+    useEffect(() => {
+      // this effect checks if the die is low velocity and colliding the plane.
+      // if so, then it starts an interval/timer to see if that persists for half a second.
+      // if so, sets atRest to true
+      if (lowVelocity && collidingPlane && !atRest) {
+        interval.current = setInterval(() => {
+          onRest();
+        }, 500);
+      } else if (!lowVelocity || !collidingPlane) {
+        if (interval.current) {
+          clearInterval(interval.current);
+                  }
+        if (atRest) {
+          setAtRest(false);
+        }
+      }
+      return () => clearInterval(interval.current);
+    }, [collidingPlane, interval.current, lowVelocity]);
+
+    useEffect(() => {
+      // when the die first loads, spin it
+      api.angularVelocity.set(...randomAngularVelocity());
+    }, []);
+
+    useFrame(() => {
+      // this hook gets the current centroids of the geometry's faces
+      if (ref) {
+        centroidsRef.current = CannonUtils.getCentroids(geometry);
+      }
+    });
+
+    return (
+      <>
+        <mesh
+          ref={ref}
+          receiveShadow
+          castShadow
+          onClick={(event) => {
+            if (atRest) {
+              resetRoll();
+            }
+          }}
+          onPointerOver={(event) => setHover(true)}
+          onPointerOut={(event) => setHover(false)}
+        >
+          {children}
+          <meshStandardMaterial
+            color={
+              hovered && atRest
+                ? "yellow"
+                : atRest
+                ? color.clone().add(new Color(0.5, 0.5, 0.5))
+                : color
+            }
+          />
+          {/* {centroidsRef.current.map((centroid, index) => (
+            <Text
+              key={index}
+              position={centroid}
+              fontSize={0.5}
+              color="white"
+              anchorY="middle"
+            >
+              {index + 1}
+            </Text>
+          ))} */}
+        </mesh>
+      </>
+    );
+  }
+);
+
+export default Dx;

--- a/src/Vec3Utils.jsx
+++ b/src/Vec3Utils.jsx
@@ -1,0 +1,19 @@
+export const randomRotation = () => {
+  return [
+    Math.random() * Math.PI,
+    Math.random() * Math.PI,
+    Math.random() * Math.PI,
+  ];
+};
+
+export const randomVelocity = () => {
+  return [Math.random() * 3, Math.random() * 3, Math.random() * 3];
+};
+
+export const randomAngularVelocity = () => {
+  return [
+    Math.random() * 20 - 10,
+    Math.random() * 20 - 10,
+    Math.random() * 20 - 10,
+  ];
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,8 @@
+export const ZEROISH = 0.07;
+
+export const D4_RADIUS = 1;
+export const D6_RADIUS = 1.3;
+export const D8_RADIUS = 0.9;
+export const D10_RADIUS = 1;
+export const D12_RADIUS = 0.9;
+export const D20_RADIUS = 1;


### PR DESCRIPTION
This abstractifies the generic Dice logic into a `Dx` class, and has each specific shape generate its own geometry and physics representation before passing that down.

There's definitely some more abstraction that could be done here but it works well enough to get all 6 needed shapes working.