### PR TITLE
vn/roll results

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,14 +18,14 @@ const App = () => {
   return (
     <Canvas
       shadows
-      camera={{ position: [8, 8, 8] }}
+      camera={{ position: [12, 12, 12] }}
       dpr={[1, 2]}
       gl={{ alpha: false }}
     >
       <directionalLight
         castShadow
-        position={[2.5, 8, 5]}
-        shadow-mapSize={[1024, 1024]}
+        position={[2.5, 30, 5]}
+        shadow-mapSize={[4096, 4096]}
       >
         <orthographicCamera attach="shadow-camera" args={[-10, 10, 10, -10]} />
       </directionalLight>
@@ -40,6 +40,7 @@ const App = () => {
         <D8 position={[3, 3, 5]} color={new Color("orange")} />
         <D6 position={[2, 3, -5]} color={new Color("green")} />
         <D4 position={[-1, 3, 5]} color={new Color("grey")} />
+
       </Physics>
       <OrbitControls />
     </Canvas>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,9 +25,9 @@ const App = () => {
       <directionalLight
         castShadow
         position={[2.5, 30, 5]}
-        shadow-mapSize={[4096, 4096]}
+        shadow-mapSize={[1024, 1024]}
       >
-        <orthographicCamera attach="shadow-camera" args={[-10, 10, 10, -10]} />
+        <orthographicCamera attach="shadow-camera" args={[-20, 20, 20, -20]} />
       </directionalLight>
       <Physics>
         <Suspense>
@@ -40,7 +40,6 @@ const App = () => {
         <D8 position={[3, 3, 5]} color={new Color("orange")} />
         <D6 position={[2, 3, -5]} color={new Color("green")} />
         <D4 position={[-1, 3, 5]} color={new Color("grey")} />
-
       </Physics>
       <OrbitControls />
     </Canvas>

--- a/src/CannonUtils.jsx
+++ b/src/CannonUtils.jsx
@@ -5,6 +5,7 @@
 import * as THREE from "three";
 
 class CannonUtils {
+  // turns mesh information into physics compatible format
   static toConvexPolyhedronProps(geometry) {
     const position = geometry.attributes.position;
     const normal = geometry.attributes.normal;
@@ -78,6 +79,9 @@ class CannonUtils {
     return [points.map((v) => [v.x, v.y, v.z]), cannonFaces];
   }
 
+  // returns the list of all centroids of the geometry
+  // may return more than the conventional number of centroids
+  // due to some faces containing multiple triangles
   static getCentroids(geometry) {
     const position = geometry.attributes.position;
     const vertices = [];
@@ -99,7 +103,101 @@ class CannonUtils {
       centroids.push(centroid);
     }
 
+    // TODO: handle cases where there are multiple triangles per face
+
     return centroids;
+  }
+
+  // returns the list of all vertices of the geometry
+  static getVertices(geometry) {
+    const position = geometry.attributes.position;
+    const vertices = [];
+    for (let i = 0; i < position.count; i++) {
+      vertices.push(new THREE.Vector3().fromBufferAttribute(position, i));
+    }
+
+    const verticesMap = {};
+    const points = [];
+    const changes = [];
+    for (let i = 0, il = vertices.length; i < il; i++) {
+      const v = vertices[i];
+      const key =
+        Math.round(v.x * 100) +
+        "_" +
+        Math.round(v.y * 100) +
+        "_" +
+        Math.round(v.z * 100);
+      if (verticesMap[key] === undefined) {
+        verticesMap[key] = i;
+        points.push({ x: vertices[i].x, y: vertices[i].y, z: vertices[i].z });
+        changes[i] = points.length - 1;
+      } else {
+        changes[i] = changes[verticesMap[key]];
+      }
+    }
+
+    return points.map((v) => new THREE.Vector3(v.x, v.y, v.z));
+  }
+
+  // returns the roll result as well as the source (centroid or vertex)
+  static getResult(mat, center, centroids, vertices) {
+    const worldCenter = new THREE.Vector3(center.x, center.y, center.z);
+    const trueVertical = new THREE.Vector3(0, 1, 0);
+    let largestDotProd = -Infinity;
+    let result;
+    let resultType;
+
+    centroids.map((c, index) => {
+      const worldPosition = new THREE.Vector3(c.x, c.y, c.z).applyMatrix4(mat);
+      const direction = new THREE.Vector3()
+        .subVectors(worldPosition, worldCenter)
+        .normalize();
+      const dotProd = direction.dot(trueVertical);
+      if (dotProd > largestDotProd) {
+        largestDotProd = dotProd;
+        result = index + 1;
+        resultType = "centroid";
+      }
+    });
+
+    vertices.map((v, index) => {
+      const worldPosition = new THREE.Vector3(v.x, v.y, v.z).applyMatrix4(mat);
+      const direction = new THREE.Vector3()
+        .subVectors(worldPosition, worldCenter)
+        .normalize();
+      const dotProd = direction.dot(trueVertical);
+      if (dotProd > largestDotProd) {
+        largestDotProd = dotProd;
+        result = index + 1;
+        resultType = "vertex";
+      }
+    });
+
+    return [result, resultType];
+  }
+
+  // returns the list of face normals
+  static getNormals(geometry) {
+    const position = geometry.attributes.position;
+    const normals = [];
+    for (let i = 0; i < position.count; i += 3) {
+      const a = new THREE.Vector3().fromBufferAttribute(position, i);
+      const b = new THREE.Vector3().fromBufferAttribute(position, i + 1);
+      const c = new THREE.Vector3().fromBufferAttribute(position, i + 2);
+      const normal = new THREE.Vector3()
+        .subVectors(b, a)
+        .cross(new THREE.Vector3().subVectors(c, a))
+        .normalize();
+      normals.push(normal);
+    }
+    return normals;
+  }
+
+  // returns a quaternion that can rotate a component to lay flat on its face
+  static calculateFaceQuaternion(faceNormal) {
+    const quaternion = new THREE.Quaternion();
+    quaternion.setFromUnitVectors(new THREE.Vector3(0, 0, 1), faceNormal);
+    return quaternion;
   }
 }
 

--- a/src/CannonUtils.jsx
+++ b/src/CannonUtils.jsx
@@ -72,7 +72,10 @@ class CannonUtils {
       faces.splice(idx, 1);
     }
 
-    return [points.map((v) => [v.x, v.y, v.z]), faces.map((f) => [f.a, f.b, f.c])];
+    return [
+      points.map((v) => [v.x, v.y, v.z]),
+      faces.map((f) => [f.a, f.b, f.c]),
+    ];
   }
 
   // helper function for averaging groups of vectors
@@ -89,9 +92,7 @@ class CannonUtils {
     return averages;
   }
 
-  // returns the list of all centroids of the geometry
-  // may return more than the conventional number of centroids
-  // due to some faces containing multiple triangles
+  // returns the list of all centroids (faces)
   static getCentroids(geometry) {
     const position = geometry.attributes.position;
 
@@ -114,6 +115,8 @@ class CannonUtils {
       centroids.push(centroid);
     }
 
+    // takes average of centroid groups when shape
+    // contains faces composed of multiple triangles
     if (geometry.groupSize > 1) {
       return this.getVector3Average(centroids, geometry.groupSize);
     }
@@ -121,7 +124,7 @@ class CannonUtils {
     return centroids;
   }
 
-  // returns the list of all vertices of the geometry
+  // returns the list of vertices
   static getVertices(geometry) {
     const position = geometry.attributes.position;
     const vertices = [];
@@ -147,6 +150,8 @@ class CannonUtils {
       normals.push(normal);
     }
 
+    // takes average of normal groups when shape
+    // contains faces composed of multiple triangles
     if (geometry.groupSize > 1) {
       return this.getVector3Average(normals, geometry.groupSize);
     }
@@ -161,7 +166,8 @@ class CannonUtils {
     return quaternion;
   }
 
-  // returns the roll result as well as the source (centroid or vertex)
+  // returns the roll result by calculating dot product (a • b)
+  // where a = (center - centroid) and b = up
   static getResult(name, mat, center, centroids) {
     const worldCenter = new THREE.Vector3(center.x, center.y, center.z);
     const trueVertical =

--- a/src/D10.jsx
+++ b/src/D10.jsx
@@ -24,24 +24,34 @@ const D10 = ({ position, color }) => {
     }
 
     const faces = [
+      // 0
+      [0, 11, 2],
       [0, 2, 3],
+      // 1
       [0, 3, 4],
       [0, 4, 5],
+      // 2
       [0, 5, 6],
       [0, 6, 7],
+      // 3
       [0, 7, 8],
       [0, 8, 9],
+      // 4
       [0, 9, 10],
       [0, 10, 11],
-      [0, 11, 2],
+      // 5
       [1, 3, 2],
       [1, 4, 3],
+      // 6
       [1, 5, 4],
       [1, 6, 5],
+      // 7
       [1, 7, 6],
       [1, 8, 7],
+      // 8
       [1, 9, 8],
       [1, 10, 9],
+      // 9
       [1, 11, 10],
       [1, 2, 11],
     ].flat();
@@ -54,6 +64,7 @@ const D10 = ({ position, color }) => {
     [geometryArgs]
   );
   geometry.name = "d10";
+  geometry.groupSize = 2;
 
   const args = useMemo(
     () => CannonUtils.toConvexPolyhedronProps(geometry, 3),

--- a/src/D10.jsx
+++ b/src/D10.jsx
@@ -53,11 +53,13 @@ const D10 = ({ position, color }) => {
       new PolyhedronGeometry(geometryArgs[0], geometryArgs[1], D10_RADIUS, 0),
     [geometryArgs]
   );
+  geometry.name = "d10";
 
   const args = useMemo(
     () => CannonUtils.toConvexPolyhedronProps(geometry, 3),
     [geometry]
   );
+
   const [ref, api] = useConvexPolyhedron(() => ({
     args,
     mass: 1,

--- a/src/D12.jsx
+++ b/src/D12.jsx
@@ -13,6 +13,7 @@ const D12 = ({ position, color }) => {
 
   const geometry = useMemo(() => new DodecahedronGeometry(D12_RADIUS, 0), []);
   geometry.name = "d12";
+  geometry.groupSize = 3;
 
   const args = useMemo(
     () => CannonUtils.toConvexPolyhedronProps(geometry),

--- a/src/D12.jsx
+++ b/src/D12.jsx
@@ -12,10 +12,13 @@ const D12 = ({ position, color }) => {
   const [lastContactId, setLastContactId] = useState(null);
 
   const geometry = useMemo(() => new DodecahedronGeometry(D12_RADIUS, 0), []);
+  geometry.name = "d12";
+
   const args = useMemo(
     () => CannonUtils.toConvexPolyhedronProps(geometry),
     [geometry]
   );
+
   const [ref, api] = useConvexPolyhedron(() => ({
     args,
     mass: 1,

--- a/src/D20.jsx
+++ b/src/D20.jsx
@@ -13,6 +13,7 @@ const D20 = ({ position, color }) => {
 
   const geometry = useMemo(() => new IcosahedronGeometry(D20_RADIUS, 0), []);
   geometry.name = "d20";
+  geometry.groupSize = 1;
 
   const args = useMemo(
     () => CannonUtils.toConvexPolyhedronProps(geometry),

--- a/src/D20.jsx
+++ b/src/D20.jsx
@@ -12,10 +12,13 @@ const D20 = ({ position, color }) => {
   const [lastContactId, setLastContactId] = useState(null);
 
   const geometry = useMemo(() => new IcosahedronGeometry(D20_RADIUS, 0), []);
+  geometry.name = "d20";
+
   const args = useMemo(
     () => CannonUtils.toConvexPolyhedronProps(geometry),
     [geometry]
   );
+  
   const [ref, api] = useConvexPolyhedron(() => ({
     args,
     mass: 1,

--- a/src/D4.jsx
+++ b/src/D4.jsx
@@ -13,12 +13,13 @@ const D4 = ({ position, color }) => {
 
   const geometry = useMemo(() => new TetrahedronGeometry(D4_RADIUS, 0), []);
   geometry.name = "d4";
+  geometry.groupSize = 1;
 
   const args = useMemo(
     () => CannonUtils.toConvexPolyhedronProps(geometry),
     [geometry]
   );
-  
+
   const [ref, api] = useConvexPolyhedron(() => ({
     args,
     mass: 1,

--- a/src/D4.jsx
+++ b/src/D4.jsx
@@ -12,10 +12,13 @@ const D4 = ({ position, color }) => {
   const [lastContactId, setLastContactId] = useState(null);
 
   const geometry = useMemo(() => new TetrahedronGeometry(D4_RADIUS, 0), []);
+  geometry.name = "d4";
+
   const args = useMemo(
     () => CannonUtils.toConvexPolyhedronProps(geometry),
     [geometry]
   );
+  
   const [ref, api] = useConvexPolyhedron(() => ({
     args,
     mass: 1,

--- a/src/D6.jsx
+++ b/src/D6.jsx
@@ -11,6 +11,8 @@ const D6 = ({ position, color }) => {
   const [lastContactId, setLastContactId] = useState(null);
 
   const geometry = useMemo(() => new BoxGeometry(D6_RADIUS), []);
+  geometry.name = "d6";
+
   const [ref, api] = useBox(() => ({
     args: [D6_RADIUS, D6_RADIUS, D6_RADIUS],
     mass: 1,

--- a/src/D6.jsx
+++ b/src/D6.jsx
@@ -12,7 +12,7 @@ const D6 = ({ position, color }) => {
   const [lastContactId, setLastContactId] = useState(null);
 
   const geometryArgs = useMemo(() => {
-    const sides = 6;
+    // const sides = 6;
     const vertices = [
       [-1, -1, -1],
       [1, -1, -1],
@@ -25,16 +25,22 @@ const D6 = ({ position, color }) => {
     ].flat();
 
     const faces = [
+      // 0
       [2, 1, 0],
       [0, 3, 2],
+      // 1
       [0, 4, 7],
       [7, 3, 0],
+      // 2
       [0, 1, 5],
       [5, 4, 0],
+      // 3
       [1, 2, 6],
       [6, 5, 1],
+      // 4
       [2, 3, 7],
       [7, 6, 2],
+      // 5
       [4, 5, 6],
       [6, 7, 4],
     ].flat();

--- a/src/D6.jsx
+++ b/src/D6.jsx
@@ -12,12 +12,13 @@ const D6 = ({ position, color }) => {
 
   const geometry = useMemo(() => new BoxGeometry(D6_RADIUS), []);
   geometry.name = "d6";
+  geometry.groupSize = 1;
 
   const [ref, api] = useBox(() => ({
     args: [D6_RADIUS, D6_RADIUS, D6_RADIUS],
     mass: 1,
     position,
-    restitution: 0.8,
+    restitution: 1,
     onCollideBegin: (e) => {
       if (e.body.geometry.type === "PlaneGeometry") {
         setCollidingPlane(true);

--- a/src/D8.jsx
+++ b/src/D8.jsx
@@ -12,10 +12,13 @@ const D8 = ({ position, color }) => {
   const [lastContactId, setLastContactId] = useState(null);
 
   const geometry = useMemo(() => new OctahedronGeometry(D8_RADIUS, 0), []);
+  geometry.name = "d8";
+
   const args = useMemo(
     () => CannonUtils.toConvexPolyhedronProps(geometry, 3),
     [geometry]
   );
+  
   const [ref, api] = useConvexPolyhedron(() => ({
     args,
     mass: 1,

--- a/src/D8.jsx
+++ b/src/D8.jsx
@@ -13,6 +13,7 @@ const D8 = ({ position, color }) => {
 
   const geometry = useMemo(() => new OctahedronGeometry(D8_RADIUS, 0), []);
   geometry.name = "d8";
+  geometry.groupSize = 1;
 
   const args = useMemo(
     () => CannonUtils.toConvexPolyhedronProps(geometry, 3),

--- a/src/Dx.jsx
+++ b/src/Dx.jsx
@@ -167,8 +167,8 @@ const Dx = forwardRef(
                   color={assignColor(index)}
                   characters="0123456789"
                   quaternion={quaternion}
-                  castShadow
-                  receiveShadow
+                  // castShadow
+                  // receiveShadow
                 >
                   {`${index + 1}` + `${index === 5 || index === 8 ? "." : ""}`}
                 </Text>

--- a/src/Dx.jsx
+++ b/src/Dx.jsx
@@ -117,6 +117,9 @@ const Dx = forwardRef(
     }, []);
 
     const assignColor = useCallback(
+      // this callback sets the text color based on roll state
+      // Nat 1 turns red
+      // Nat 20 turns green
       (index) => {
         if (index === roll) {
           if (index === 0) return "red";
@@ -151,30 +154,29 @@ const Dx = forwardRef(
                 : color
             }
           />
-          {
-            // show centroid labels
-            centroids.map((centroid, index) => {
-              const quaternion = CannonUtils.calculateFaceQuaternion(
-                normals[index]
-              );
+          {centroids.map((centroid, index) => {
+            // this quaternion represents a rotation
+            // equal to the orientation of the face normal
+            const quaternion = CannonUtils.calculateFaceQuaternion(
+              normals[index]
+            );
 
-              return (
-                <Text
-                  mass={0}
-                  key={index}
-                  position={centroid.multiplyScalar(1.03)}
-                  fontSize={0.4}
-                  color={assignColor(index)}
-                  characters="0123456789"
-                  quaternion={quaternion}
-                  // castShadow
-                  // receiveShadow
-                >
-                  {`${index + 1}` + `${index === 5 || index === 8 ? "." : ""}`}
-                </Text>
-              );
-            })
-          }
+            return (
+              <Text
+                mass={0}
+                key={index}
+                position={centroid.multiplyScalar(1.03)}
+                fontSize={0.4}
+                color={assignColor(index)}
+                characters="0123456789"
+                quaternion={quaternion}
+                // castShadow
+                // receiveShadow
+              >
+                {`${index + 1}` + `${index === 5 || index === 8 ? "." : ""}`}
+              </Text>
+            );
+          })}
         </mesh>
       </>
     );

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,7 +1,7 @@
-export const ZEROISH = 0.07;
+export const ZEROISH = 0.085;
 
 export const D4_RADIUS = 1;
-export const D6_RADIUS = 1.3;
+export const D6_RADIUS = 1;
 export const D8_RADIUS = 0.9;
 export const D10_RADIUS = 1;
 export const D12_RADIUS = 0.9;


### PR DESCRIPTION
Now have geometries and roll registration set up for d4, d6, d8, d10, d12, and d20
Couple of odd edge cases include:
* failure to register roll despite being at rest (most common with d4)
* failure to register correct roll due to slight tilt (most common with d20)
* rapid toggling of at rest state causing repeated roll registration